### PR TITLE
Migration dart2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - git clone https://github.com/flutter/flutter.git -b master --depth 1
   - ./flutter/bin/flutter doctor
 script:
-  - ./flutter/bin/flutter test --coverage
+  - ./flutter/bin/flutter packages pub run build_runner test
 after_success:
   - bash <(curl -s https://codecov.io/bash) -t $CODE_COV_TOKEN
 cache:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Note: If you're not part of the Comiko project on Firebase, you can either ask t
 
 - Place it under `comiko-app/android/app`
 
+## Dart 2
+
+Take note that this repository is now set to use dart2 tools with flutter. Commands like pub build, pub test are no longer supported. Please use build runner now!
+
+```
+❯ flutter packages pub run build_runner test
+
+```
+
+
 ### Debug firebase auth
 Get your debug keystore fingerprint.
 There's no password for debug keystore, just hit enter when asked.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,22 +8,29 @@ dependencies:
   flutter_redux: "^0.5.0"
   path: "^1.4.2"
   comiko_shared:
-    git: https://github.com/comiko-app/shared.git
+    path: ../comiko_dependencies/shared
   comiko_backend:
     path: ../comiko_dependencies/backend
-#    https://github.com/comiko-app/backend.git
-  cloud_firestore: '^0.2.6'
-  font_awesome_flutter: '^6.0.0'
-  url_launcher: "^2.0.1"
+  cloud_firestore: '^0.7.4'
+  font_awesome_flutter: '^8.0.1'
+  url_launcher: "^3.0.3"
   intl: "^0.15.2"
-  cached_network_image: "^0.3.0"
+  cached_network_image: "^0.4.2"
   async_loader: '>=0.1.0 <0.2.0'
-  firebase_auth: '^0.4.5'
-  google_sign_in: "^2.1.0"
+  firebase_auth: '^0.5.19'
+  google_sign_in: "^3.0.5"
   flutter_facebook_login: '>=1.0.3 <2.0.0'
+
 dev_dependencies:
+  json_annotation: "^1.1.0"
+  build_runner: "^0.10.1+1"
+  build_test: "0.10.3+1"
   flutter_test:
     sdk: flutter
+
+# git & path require json annotation 0.2.2
+dependency_override:
+  json_annotation: "^1.1.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Update dependencies to fit SDK 2.1.0+ 

Take note that flutter test/build is no longer a valid tool 

```
❯  flutter packages pub run build_runner test
```



